### PR TITLE
chore feature/upgrade-to-quarkus-1.13.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-        <quarkus-plugin.version>1.13.2.Final</quarkus-plugin.version>
-        <quarkus.platform.version>1.13.2.Final</quarkus.platform.version>
+        <quarkus-plugin.version>1.13.4.Final</quarkus-plugin.version>
+        <quarkus.platform.version>1.13.4.Final</quarkus.platform.version>
 
         <sonar.projectKey>spoud_${project.artifactId}</sonar.projectKey>
         <sonar.organization>spoud</sonar.organization>


### PR DESCRIPTION
chore upgrade quarkus,

jacoco is still now working in a mix of quarkus/non-quarkus sub module